### PR TITLE
Main Page Layout

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,22 +1,35 @@
-import type { Metadata } from "next";
-import { Geist } from "next/font/google";
-import { ThemeProvider } from "next-themes";
-import "./globals.css";
+import type { Metadata } from 'next';
+import { Geist } from 'next/font/google';
+import '@mantine/core/styles.css';
+import {
+  AppShell,
+  AppShellHeader,
+  AppShellMain,
+  BackgroundImage,
+  Center,
+  createTheme,
+  Group,
+  MantineColorsTuple,
+  MantineProvider,
+} from '@mantine/core';
+import GoHomeButton from '@/components/GoHomeButton';
+import SignUpButton from '@/components/SignUpButton';
+import './globals.css';
 
 const defaultUrl = process.env.VERCEL_URL
   ? `https://${process.env.VERCEL_URL}`
-  : "http://localhost:3000";
+  : 'http://localhost:3000';
 
 export const metadata: Metadata = {
   metadataBase: new URL(defaultUrl),
-  title: "Next.js and Supabase Starter Kit",
-  description: "The fastest way to build apps with Next.js and Supabase",
+  title: 'Next.js and Supabase Starter Kit',
+  description: 'The fastest way to build apps with Next.js and Supabase',
 };
 
 const geistSans = Geist({
-  variable: "--font-geist-sans",
-  display: "swap",
-  subsets: ["latin"],
+  variable: '--font-geist-sans',
+  display: 'swap',
+  subsets: ['latin'],
 });
 
 export default function RootLayout({
@@ -24,17 +37,63 @@ export default function RootLayout({
 }: Readonly<{
   children: React.ReactNode;
 }>) {
+  const myGreen: MantineColorsTuple = [
+    '#e9fcf0',
+    '#daf3e2',
+    '#b5e5c5',
+    '#8ed6a6',
+    '#6dca8b',
+    '#58c27a',
+    '#4bbf71',
+    '#3dad62',
+    '#309553',
+    '#208144',
+  ];
+  const myYellow: MantineColorsTuple = [
+    '#fff8e1',
+    '#ffefcb',
+    '#ffdd9a',
+    '#ffca64',
+    '#ffba38',
+    '#ffb01b',
+    '#ffa903',
+    '#e39500',
+    '#cb8400',
+    '#b07100',
+  ];
+
+  const theme = createTheme({
+    colors: {
+      myGreen,
+      myYellow,
+    },
+    autoContrast: true,
+  });
   return (
-    <html lang="en" suppressHydrationWarning>
+    <html lang='en' suppressHydrationWarning>
       <body className={`${geistSans.className} antialiased`}>
-        <ThemeProvider
-          attribute="class"
-          defaultTheme="system"
-          enableSystem
-          disableTransitionOnChange
-        >
-          {children}
-        </ThemeProvider>
+        <MantineProvider theme={theme}>
+          <BackgroundImage src=''>
+            <Center>
+              <AppShell header={{ height: 60 }} padding={'xs'} w={'75%'}>
+                <AppShellHeader>
+                  <Group
+                    justify={'space-between'}
+                    h={'100%'}
+                    w={'100%'}
+                    pr={'sm'}
+                    bg={theme.colors?.myGreen[1]}
+                    miw={'345px'}
+                  >
+                    <GoHomeButton />
+                    <SignUpButton />
+                  </Group>
+                </AppShellHeader>
+                <AppShellMain>{children}</AppShellMain>
+              </AppShell>
+            </Center>
+          </BackgroundImage>
+        </MantineProvider>
       </body>
     </html>
   );

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -82,7 +82,9 @@ export default function RootLayout({
                     h={'100%'}
                     w={'100%'}
                     pr={'sm'}
-                    bg={theme.colors?.myGreen[1]}
+                    bg={
+                      theme.colors?.myGreen ? theme.colors.myGreen[1] : 'white'
+                    }
                     miw={'345px'}
                   >
                     <GoHomeButton />

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,3 +1,8 @@
+import HomePage from '@/components/HomePage';
 export default function Home() {
-  return <main className='min-h-screen flex flex-col items-center'>hello</main>;
+  return (
+    <main className='min-h-screen flex flex-col items-center'>
+      <HomePage />
+    </main>
+  );
 }

--- a/components/FeaturedRecipe.tsx
+++ b/components/FeaturedRecipe.tsx
@@ -1,0 +1,6 @@
+import RecipeCard from './RecipeCard';
+
+export const FeaturedRecipe = () => {
+  return <RecipeCard />;
+};
+export default FeaturedRecipe;

--- a/components/GoHomeButton.tsx
+++ b/components/GoHomeButton.tsx
@@ -1,0 +1,29 @@
+'use client';
+
+import { Button, useMantineTheme } from '@mantine/core';
+import { House } from 'lucide-react';
+
+export const GoHomeButton = () => {
+  const theme = useMantineTheme();
+
+  const handleClick = () => {
+    if (typeof window !== undefined) {
+      const homeUrl = window.location.origin;
+      window.location.href = homeUrl;
+    }
+  };
+
+  return (
+    <Button
+      h={'100%'}
+      variant='subtle'
+      leftSection={<House />}
+      onClick={handleClick}
+      size='lg'
+      c={theme.colors.myGreen[9]}
+    >
+      Go Home
+    </Button>
+  );
+};
+export default GoHomeButton;

--- a/components/HomePage.tsx
+++ b/components/HomePage.tsx
@@ -1,0 +1,24 @@
+import { AspectRatio, Flex, Group, Paper, Stack } from '@mantine/core';
+import RandomRecipe from './RandomRecipe';
+import FeaturedRecipe from './FeaturedRecipe';
+
+const HomePage = () => {
+  return (
+    <Stack w={'100%'}>
+      <AspectRatio ratio={16 / 9} flex={'0,0,100%'}>
+        <Paper withBorder bg={'#EEEEEE'}>
+          <Flex h={'100%'} align={'center'} justify={'center'}>
+            Search for Your Favorite Recipes:
+            <br />
+            (Insert Search element here)
+          </Flex>
+        </Paper>
+      </AspectRatio>
+      <Group grow p='0' h={'100%'}>
+        <RandomRecipe />
+        <FeaturedRecipe />
+      </Group>
+    </Stack>
+  );
+};
+export default HomePage;

--- a/components/RandomRecipe.tsx
+++ b/components/RandomRecipe.tsx
@@ -1,0 +1,6 @@
+import RecipeCard from './RecipeCard';
+
+export const RandomRecipe = () => {
+  return <RecipeCard />;
+};
+export default RandomRecipe;

--- a/components/RecipeCard.tsx
+++ b/components/RecipeCard.tsx
@@ -1,0 +1,6 @@
+import { Paper } from '@mantine/core';
+
+export const RecipeCard = () => {
+  return <Paper withBorder> this is a recipe card</Paper>;
+};
+export default RecipeCard;

--- a/components/SignUpButton.tsx
+++ b/components/SignUpButton.tsx
@@ -1,0 +1,30 @@
+'use client';
+
+import { Button, useMantineTheme } from '@mantine/core';
+import { User } from 'lucide-react';
+
+export const SignUpButton = () => {
+  const theme = useMantineTheme();
+
+  const handleClick = () => {
+    if (typeof window !== undefined) {
+      const homeUrl = window.location.origin;
+      window.location.href = homeUrl;
+    }
+  };
+
+  return (
+    <Button
+      h={'70%'}
+      variant='filled'
+      radius={'xl'}
+      rightSection={<User />}
+      onClick={handleClick}
+      size='lg'
+      color={theme.colors.myYellow[3]}
+    >
+      Sign Up
+    </Button>
+  );
+};
+export default SignUpButton;


### PR DESCRIPTION
- Added Basic Layout formatting to the landing page of the site
- Additionally added a header that has a button to always take you back to the home page and a sign up button that will eventually lead to a sign in page (currently redirects to home page as well)
- create an theme with 2 main colors (myYellow and myGreen)

To Test:

- Verify that you can run 'npm run build' without any errors
- click on go Home button and verify it refreshes the page
- take a look at the layout and make sure i'm not missing anything crucial